### PR TITLE
正規表現として扱われる文字列内にあるピリオドをエスケープしました。

### DIFF
--- a/seasar2/s2-extension/src/main/java/org/seasar/extension/j2ee/JndiContext.java
+++ b/seasar2/s2-extension/src/main/java/org/seasar/extension/j2ee/JndiContext.java
@@ -74,7 +74,7 @@ public class JndiContext implements Context {
 
     public void bind(final String name, final Object obj)
             throws NamingException {
-        bind(JndiResourceLocator.resolveName(name).split("."), obj);
+        bind(JndiResourceLocator.resolveName(name).split("\\."), obj);
     }
 
     public void close() throws NamingException {

--- a/seasar2/s2-extension/src/test/java/org/seasar/extension/j2ee/JndiContextTest.java
+++ b/seasar2/s2-extension/src/test/java/org/seasar/extension/j2ee/JndiContextTest.java
@@ -23,7 +23,7 @@ import org.seasar.extension.unit.S2TestCase;
 
 /**
  * @author koichik
- *
+ * 
  */
 public class JndiContextTest extends S2TestCase {
 
@@ -45,6 +45,16 @@ public class JndiContextTest extends S2TestCase {
         assertNotNull("1", ctx_.lookup("java:comp/env/jdbc/dataSource"));
         assertNotNull("2", ctx_.lookup("java:comp/env/j2ee/jdbc/dataSource"));
         assertNotNull("3", ctx_.lookup("java:comp/UserTransaction"));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public void testBind() throws Exception {
+        include("bind.dicon");
+        Object obj = new Object();
+        ctx_.bind("bind.Hoge", obj);
+        assertNotNull(ctx_.lookup("bind/Hoge"));
     }
 
     protected void setUp() throws Exception {

--- a/seasar2/s2-extension/src/test/resources/org/seasar/extension/j2ee/bind.dicon
+++ b/seasar2/s2-extension/src/test/resources/org/seasar/extension/j2ee/bind.dicon
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="Shift_JIS"?>
+<!DOCTYPE components PUBLIC "-//SEASAR//DTD S2Container//EN"
+"http://www.seasar.org/dtd/components.dtd">
+<components namespace="bind">
+</components>


### PR DESCRIPTION
bindメソッド内で次のようなコードがあります。

> JndiResourceLocator.resolveName(name).split(".")

これは例えば "foo.bar.baz" といった文字列が渡された場合にピリオドで分割して { "foo", "bar", "baz" } という配列に変換されることを期待しています。
しかしString#split(String)は引数の文字列を正規表現として扱うのでこのコードだとすべての文字で分割されてしまいます。
以上のことから期待する動作を確認するためのテストコードを追加してbindメソッドを修正しました。
