### PR TITLE
MockHttpServletRequestでリクエストボディを設定・取得できるようにしました。

### DIFF
--- a/seasar2/s2-framework/src/main/java/org/seasar/framework/mock/servlet/MockHttpServletRequest.java
+++ b/seasar2/s2-framework/src/main/java/org/seasar/framework/mock/servlet/MockHttpServletRequest.java
@@ -28,6 +28,13 @@ import javax.servlet.http.HttpServletRequest;
 public interface MockHttpServletRequest extends HttpServletRequest {
 
     /**
+     * コンテンツを設定します。
+     * 
+     * @param content
+     */
+    void setContent(byte[] content);
+
+    /**
      * パラメータを追加します。
      * 
      * @param name

--- a/seasar2/s2-framework/src/main/java/org/seasar/framework/mock/servlet/MockHttpServletRequestImpl.java
+++ b/seasar2/s2-framework/src/main/java/org/seasar/framework/mock/servlet/MockHttpServletRequestImpl.java
@@ -16,8 +16,11 @@
 package org.seasar.framework.mock.servlet;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -74,6 +77,8 @@ public class MockHttpServletRequestImpl implements MockHttpServletRequest {
     private Map attributes = new HashMap();
 
     private String characterEncoding = "ISO-8859-1";
+
+    private byte[] content;
 
     private int contentLength;
 
@@ -440,17 +445,22 @@ public class MockHttpServletRequestImpl implements MockHttpServletRequest {
     /**
      * @see javax.servlet.ServletRequest#setCharacterEncoding(java.lang.String)
      */
-    public void setCharacterEncoding(String characterEncoding)
-            throws UnsupportedEncodingException {
-
+    public void setCharacterEncoding(String characterEncoding) {
         this.characterEncoding = characterEncoding;
+    }
+
+    /**
+     * @see org.seasar.framework.mock.servlet.MockHttpServletRequest#setContent(byte[])
+     */
+    public void setContent(byte[] content) {
+        this.content = content;
     }
 
     /**
      * @see javax.servlet.ServletRequest#getContentLength()
      */
     public int getContentLength() {
-        return contentLength;
+        return (this.content != null ? this.content.length : this.contentLength);
     }
 
     public void setContentLength(int contentLength) {
@@ -472,7 +482,12 @@ public class MockHttpServletRequestImpl implements MockHttpServletRequest {
      * @see javax.servlet.ServletRequest#getInputStream()
      */
     public ServletInputStream getInputStream() throws IOException {
-        throw new UnsupportedOperationException();
+        if (this.content != null) {
+            return new MockServletInputStreamImpl(new ByteArrayInputStream(
+                    this.content));
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -590,11 +605,22 @@ public class MockHttpServletRequestImpl implements MockHttpServletRequest {
     }
 
     /**
-     * 
      * @see javax.servlet.ServletRequest#getReader()
      */
     public BufferedReader getReader() throws IOException {
-        throw new UnsupportedOperationException();
+        if (this.content != null) {
+            InputStream sourceStream = new ByteArrayInputStream(this.content);
+            Reader sourceReader;
+            if (this.characterEncoding != null) {
+                sourceReader = new InputStreamReader(sourceStream,
+                        this.characterEncoding);
+            } else {
+                sourceReader = new InputStreamReader(sourceStream);
+            }
+            return new BufferedReader(sourceReader);
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/seasar2/s2-framework/src/main/java/org/seasar/framework/mock/servlet/MockServletInputStream.java
+++ b/seasar2/s2-framework/src/main/java/org/seasar/framework/mock/servlet/MockServletInputStream.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2004-2014 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.framework.mock.servlet;
+
+import javax.servlet.ServletInputStream;
+
+/**
+ * モック用の{@link ServletInputStream}の抽象クラスです。
+ * 
+ * @author Jun Futagawa
+ */
+public abstract class MockServletInputStream extends ServletInputStream {
+
+}

--- a/seasar2/s2-framework/src/main/java/org/seasar/framework/mock/servlet/MockServletInputStreamImpl.java
+++ b/seasar2/s2-framework/src/main/java/org/seasar/framework/mock/servlet/MockServletInputStreamImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2004-2014 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.framework.mock.servlet;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * {@link MockServletInputStream}の実装クラスです。
+ * 
+ * @author Jun Futagawa
+ */
+public class MockServletInputStreamImpl extends MockServletInputStream {
+
+    private final InputStream sourceStream;
+
+    /**
+     * {@link MockServletInputStreamImpl}を作成します。
+     * 
+     * @param sourceStream
+     */
+    public MockServletInputStreamImpl(final InputStream sourceStream) {
+        this.sourceStream = sourceStream;
+    }
+
+    /**
+     * sourceStreamを返します。
+     * 
+     * @return
+     */
+    public final InputStream getSourceStream() {
+        return this.sourceStream;
+    }
+
+    /**
+     * @see java.io.InputStream#read()
+     */
+    public int read() throws IOException {
+        return this.sourceStream.read();
+    }
+
+    /**
+     * @see java.io.InputStream#close()
+     */
+    public void close() throws IOException {
+        super.close();
+        this.sourceStream.close();
+    }
+
+}

--- a/seasar2/s2-framework/src/test/java/org/seasar/framework/mock/servlet/MockHttpServletRequestImplTest.java
+++ b/seasar2/s2-framework/src/test/java/org/seasar/framework/mock/servlet/MockHttpServletRequestImplTest.java
@@ -17,6 +17,9 @@ package org.seasar.framework.mock.servlet;
 
 import junit.framework.TestCase;
 
+import org.seasar.framework.util.InputStreamUtil;
+import org.seasar.framework.util.ReaderUtil;
+
 /**
  * @author higa
  *
@@ -47,6 +50,18 @@ public class MockHttpServletRequestImplTest extends TestCase {
         assertEquals("8", "222", values[1]);
         assertEquals("9", "333", values[2]);
         assertEquals("10", "444", values[3]);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public void testSetContent() throws Exception {
+        String content = "aaa";
+        request_.setContent(content.getBytes());
+        assertEquals("1", content.length(), request_.getContentLength());
+        assertEquals("2", content,
+                new String(InputStreamUtil.getBytes(request_.getInputStream())));
+        assertEquals("3", content, ReaderUtil.readText(request_.getReader()));
     }
 
     protected void setUp() throws Exception {


### PR DESCRIPTION
テストでJSONによるリクエストなどを再現する時に必要になります。
設定する setContent(byte[] content); は、Spring Test の MockHttpServletRequest に揃えています。
