### PR TITLE
[AOP] duplicate class definitionエラーを修正 [Seasar-user:21926]

### DIFF
--- a/seasar2/s2-framework/src/main/java/org/seasar/framework/aop/javassist/AspectWeaver.java
+++ b/seasar2/s2-framework/src/main/java/org/seasar/framework/aop/javassist/AspectWeaver.java
@@ -62,6 +62,11 @@ public class AspectWeaver {
     public static final String SUFFIX_INVOKE_SUPER_METHOD = "$$invokeSuperMethod$$";
 
     /**
+     * エンハンスされる{@link MethodInvocation}のメソッド部とインデックスの区切り文字。
+     */
+    public static final String SEPARATOR_METHOD_INVOCATION_CLASS = "$$";
+
+    /**
      * エンハンスされるクラス名の {@link Set}
      */
     protected static final Set enhancedClassNames = Collections
@@ -215,7 +220,8 @@ public class AspectWeaver {
      */
     public String getMethodInvocationClassName(final Method method) {
         return enhancedClassName + SUFFIX_METHOD_INVOCATION_CLASS
-                + method.getName() + methodInvocationClassList.size();
+                + method.getName() + SEPARATOR_METHOD_INVOCATION_CLASS
+                + methodInvocationClassList.size();
     }
 
     /**

--- a/seasar2/s2-framework/src/test/java/org/seasar/framework/aop/javassist/AspectWeaverTest.java
+++ b/seasar2/s2-framework/src/test/java/org/seasar/framework/aop/javassist/AspectWeaverTest.java
@@ -69,7 +69,21 @@ public class AspectWeaverTest extends TestCase {
                 .getMethod("hashCode", null));
         assertTrue("1", name1
                 .startsWith("$$java.lang.Object$$EnhancedByS2AOP$$"));
-        assertTrue("2", name1.endsWith("hashCode0"));
+        assertTrue("2", name1.endsWith("hashCode$$0"));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public void testSetInterceptor() throws Exception {
+        AspectWeaver weaver = new AspectWeaver(OrdinalMethods.class, null);
+        for (int i = 1; i <= 10; ++i) {
+            weaver.setInterceptors(
+                    OrdinalMethods.class.getMethod("test" + i, null),
+                    new MethodInterceptor[0]);
+        }
+        weaver.setInterceptors(OrdinalMethods.class.getMethod("test", null),
+                new MethodInterceptor[0]);
     }
 
     /**
@@ -219,4 +233,74 @@ public class AspectWeaverTest extends TestCase {
         }
 
     }
+    /**
+    *
+    */
+   public static class OrdinalMethods {
+       /**
+        * 
+        */
+       public void test1() {
+       };
+
+       /**
+        * 
+        */
+       public void test2() {
+       };
+
+       /**
+        * 
+        */
+       public void test3() {
+       };
+
+       /**
+        * 
+        */
+       public void test4() {
+       };
+
+       /**
+        * 
+        */
+       public void test5() {
+       };
+
+       /**
+        * 
+        */
+       public void test6() {
+       };
+
+       /**
+        * 
+        */
+       public void test7() {
+       };
+
+       /**
+        * 
+        */
+       public void test8() {
+       };
+
+       /**
+        * 
+        */
+       public void test9() {
+       };
+
+       /**
+        * 
+        */
+       public void test10() {
+       };
+
+       /**
+        * 
+        */
+       public void test() {
+       };
+   }
 }


### PR DESCRIPTION
AOPを適用するとメソッド毎に呼び出し用のクラスを動的に生成するが、そのクラス名は対象メソッド名の末尾にインデックスを付けていた。そのため序数を持つメソッドにAOPを適用すると、以下のように生成されるクラス名が重複し、duplicate class definitionエラーが発生する場合があった。
- "test1"にインデックス"0"で"test10"
- "test"にインデックス"10"で"test10"

対策としてメソッド名とインデックスの間に"$$"を付けて以下となるようにした。
- "test1"にインデックス"0"で"test1$$0"
- "test"にインデックス"10"で"test$$10"

http://ml.seasar.org/archives/seasar-user/2014-July/021929.html
