### PR TITLE
[S2JDBC]Likeで使うワイルドカードを変更可能にしました [Seasar-user:21947]

### DIFF
--- a/s2-tiger/src/main/java/org/seasar/extension/jdbc/util/LikeUtil.java
+++ b/s2-tiger/src/main/java/org/seasar/extension/jdbc/util/LikeUtil.java
@@ -37,6 +37,85 @@ public class LikeUtil {
     protected static final char WILDCARD_ESCAPE_CHAR = '$';
 
     /**
+     * LIKE 述語で指定される検索条件中のワイルドカードのパターン
+     * 
+     * @see #WILDCARD_PATTERN
+     * */
+    protected static Pattern wildcardPattern;
+
+    /**
+     * LIKE 述語で指定される検索条件中のワイルドカードを置換するためのパターン
+     * 
+     * @see #WILDCARD_REPLACEMENT_PATTERN
+     * */
+    protected static Pattern wildcardReplacementPattern;
+
+    /**
+     * LIKE 述語で指定される検索条件中のワイルドカードのパターンを返します。
+     * 
+     * @return LIKE 述語で指定される検索条件中のワイルドカードのパターン
+     */
+    public static Pattern getWildcardPattern() {
+        if (wildcardPattern == null) {
+            return WILDCARD_PATTERN;
+        }
+        return wildcardPattern;
+    }
+
+    /**
+     * LIKE 述語で指定される検索条件中のワイルドカードのパターンを設定します。
+     * 
+     * @param pattern
+     *            LIKE 述語で指定される検索条件中のワイルドカードのパターン
+     */
+    public static void setWildcardPattern(final Pattern pattern) {
+        wildcardPattern = pattern;
+    }
+
+    /**
+     * LIKE 述語で指定される検索条件中のワイルドカードのパターンを文字列で設定します。
+     * 
+     * @param pattern
+     *            LIKE 述語で指定される検索条件中のワイルドカードのパターン文字列
+     */
+    public static void setWildcardPatternAsString(final String pattern) {
+        setWildcardPattern(Pattern.compile(pattern));
+    }
+
+    /**
+     * LIKE 述語で指定される検索条件中のワイルドカードを置換するためのパターンを返します。
+     * 
+     * @return LIKE 述語で指定される検索条件中のワイルドカードを置換するためのパターン
+     */
+    public static Pattern getWildcardReplacementPattern() {
+        if (wildcardReplacementPattern == null) {
+            return WILDCARD_REPLACEMENT_PATTERN;
+        }
+        return wildcardReplacementPattern;
+    }
+
+    /**
+     * LIKE 述語で指定される検索条件中のワイルドカードを置換するためのパターンを設定します。
+     * 
+     * @param pattern
+     *            LIKE 述語で指定される検索条件中のワイルドカードを置換するためのパターン
+     */
+    public static void setWildcardReplacementPattern(final Pattern pattern) {
+        wildcardReplacementPattern = pattern;
+    }
+
+    /**
+     * LIKE 述語で指定される検索条件中のワイルドカードを置換するためのパターンを文字列で設定します。
+     * 
+     * @param pattern
+     *            LIKE 述語で指定される検索条件中のワイルドカードを置換するためのパターン文字列
+     */
+    public static void setWildcardReplacementPatternAsString(
+            final String pattern) {
+        setWildcardReplacementPattern(Pattern.compile(pattern));
+    }
+
+    /**
      * LIKE述語で使用される検索条件のワイルドカードが含まれていれば<code>true</code>を返します。
      * 
      * @param likeCondition
@@ -44,7 +123,7 @@ public class LikeUtil {
      * @return LIKE述語で使用される検索条件のワイルドカードが含まれていれば<code>true</code>
      */
     public static boolean containsWildcard(final String likeCondition) {
-        final Matcher matcher = WILDCARD_PATTERN.matcher(likeCondition);
+        final Matcher matcher = getWildcardPattern().matcher(likeCondition);
         return matcher.find();
     }
 
@@ -56,7 +135,7 @@ public class LikeUtil {
      * @return ワイルドカードを<code>'$'</code>でエスケープした文字列
      */
     public static String escapeWildcard(final String likeCondition) {
-        final Matcher matcher = WILDCARD_REPLACEMENT_PATTERN
+        final Matcher matcher = getWildcardReplacementPattern()
                 .matcher(likeCondition);
         return matcher.replaceAll("\\$$0");
     }

--- a/s2-tiger/src/test/java/org/seasar/extension/jdbc/util/LikeUtilTest.java
+++ b/s2-tiger/src/test/java/org/seasar/extension/jdbc/util/LikeUtilTest.java
@@ -22,6 +22,12 @@ import junit.framework.TestCase;
  */
 public class LikeUtilTest extends TestCase {
 
+    @Override
+    protected void tearDown() throws Exception {
+        LikeUtil.setWildcardPattern(null);
+        LikeUtil.setWildcardReplacementPattern(null);
+    }
+
     /**
      * 
      */
@@ -37,9 +43,33 @@ public class LikeUtilTest extends TestCase {
     /**
      * 
      */
+    public void testContainsWildcard_modifiedPattern() {
+        LikeUtil.setWildcardPatternAsString("[%_]");
+
+        assertFalse(LikeUtil.containsWildcard("aaa"));
+        assertFalse(LikeUtil.containsWildcard("$"));
+        assertTrue(LikeUtil.containsWildcard("%"));
+        assertTrue(LikeUtil.containsWildcard("_"));
+        assertFalse(LikeUtil.containsWildcard("％"));
+        assertFalse(LikeUtil.containsWildcard("＿"));
+    }
+
+    /**
+     * 
+     */
     public void testEscapeWildcard() {
         assertEquals("aaa", LikeUtil.escapeWildcard("aaa"));
         assertEquals("a$$a$%a$_a$％a$＿a", LikeUtil.escapeWildcard("a$a%a_a％a＿a"));
+    }
+
+    /**
+     * 
+     */
+    public void testEscapeWildcard_modifiedPaattern() {
+        LikeUtil.setWildcardReplacementPatternAsString("[$%_]");
+
+        assertEquals("aaa", LikeUtil.escapeWildcard("aaa"));
+        assertEquals("a$$a$%a$_a％a＿a", LikeUtil.escapeWildcard("a$a%a_a％a＿a"));
     }
 
 }


### PR DESCRIPTION
http://ml.seasar.org/archives/seasar-user/2014-September/021950.html

以前のOracleでは、全角の`"％"`および`"＿"`もワイルドカード文字であったため、エスケープの対象としていた。しかし最近のOracleでは全角の`"％"`および`"＿"`はワイルドカード文字ではなくなり、エスケープするとSQLエラーとなる。

そのため、ワイルドカードを変更できるよう`LikeUtil`にgetter/settterを追加した。

旧バージョンのS2JDBCにおいてこの問題を回避するために、`LikeUtil`の定数フィールドをリフレクションで変更しているユーザが実在するため、互換性を損なわないように修正した。
具体的には、明示的にワイルドカードを設定していない場合にgetterは既存の定数を参照するようにしている。
追加したフィールドの初期値に定数を設定し、getterは常にフィールドを参照する方が自然な実装ではあるが、その場合はリフレクションで定数を変更してもgetterはその値を参照しないので互換性を失ってしまう。そのためこの方式は採用しなかった。
