### PR TITLE
Timestamp変換処理の修正

### DIFF
--- a/seasar2/s2-framework/src/main/java/org/seasar/framework/util/TimestampConversionUtil.java
+++ b/seasar2/s2-framework/src/main/java/org/seasar/framework/util/TimestampConversionUtil.java
@@ -40,7 +40,7 @@ public class TimestampConversionUtil {
      * @return {@link Timestamp}
      */
     public static Timestamp toTimestamp(Object o) {
-        return toTimestamp(o, null);
+        return toTimestamp(o, getPattern(Locale.getDefault()));
     }
 
     /**

--- a/seasar2/s2-framework/src/test/java/org/seasar/framework/util/TimestampConversionUtilTest.java
+++ b/seasar2/s2-framework/src/test/java/org/seasar/framework/util/TimestampConversionUtilTest.java
@@ -32,4 +32,18 @@ public class TimestampConversionUtilTest extends TestCase {
         assertEquals("yyyy/MM/dd HH:mm:ss", TimestampConversionUtil
                 .getPattern(Locale.JAPANESE));
     }
+    
+    public void testToTimestamp() {
+        Locale defaultLocale = Locale.getDefault();
+        
+        Locale.setDefault(Locale.JAPANESE);
+        assertEquals("2014-12-13 14:15:16.0", TimestampConversionUtil
+                .toTimestamp("2014/12/13 14:15:16").toString());
+        
+        Locale.setDefault(Locale.ENGLISH);
+        assertEquals("2014-12-13 14:15:16.0", TimestampConversionUtil
+                .toTimestamp("12/13/2014 14:15:16").toString());
+        
+        Locale.setDefault(defaultLocale);
+    }
 }


### PR DESCRIPTION
パターン文字列を指定しない方の変換処理で、時刻情報（時、分、秒）が切り捨てられないようにしました。